### PR TITLE
feat: 면접 선택 페이지 이동시 상단 이동 & 면접 질문개수 총 0개면 면접시작 X

### DIFF
--- a/2023winterbootcamp/src/Choosepage.tsx
+++ b/2023winterbootcamp/src/Choosepage.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState, Suspense } from "react";
-import styled from "styled-components";
+import React, { useEffect, useState, Suspense, useCallback } from "react";
+import styled, { css } from "styled-components";
 import { useNavigate } from "react-router-dom";
 import api from "./baseURL/baseURL";
 import LoadingModal from "./components/LoadingModal";
@@ -336,12 +336,14 @@ const Start = styled.button<{ $startClicked: boolean }>`
   margin-bottom: 100px;
   margin-left: 70%;
   border: none;
-  cursor: pointer;
   user-select: none;
-  &:hover {
-    background-color: ${(props) =>
-      props.$startClicked ? "#1a1a1a" : "#1a1a1a"};
+  ${(props) => props.$startClicked && css`
+    cursor: pointer;
+    &:hover {
+    background-color: "#1a1a1a";
   }
+  `}
+  
 `;
 
 const DropdownContainer = styled.div`
@@ -548,20 +550,18 @@ function Choose() {
   // question_type의 count가 바뀔때마다 실행
   useEffect(() => {
     updateSelectedQuestionCounts();
-    console.log(questionState);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [projectCount, csCount, personalityCount]);
 
   // 모든 칸이 입력돼야 면접을 시작할 수 있음
   useEffect(() => {
     const isAllSelected =
-      selectedMultiButtons.length > 0 &&
+      Boolean(projectCount || csCount || personalityCount) &&
       selectedPosition !== null &&
       selectedInterviewType !== null &&
       selectedResume !== null &&
       selectedRepos.length > 0 &&
       title !== "";
-
     setStartClicked(isAllSelected);
   }, [
     selectedMultiButtons,
@@ -570,6 +570,9 @@ function Choose() {
     selectedResume,
     selectedRepos,
     title,
+    projectCount,
+    csCount,
+    personalityCount,
   ]);
 
   // 면접 제목 Change 이벤트 함수
@@ -637,23 +640,19 @@ function Choose() {
   // 선택 완료 버튼 클릭 이벤트 함수 (다른 페이지로 이동)
   const handleStartClick = (id: number) => {
     setStartClicked(true);
-    // 다른 페이지로 이동하는 대신 현재 페이지의 URL을 변경하여 Choose 페이지로 이동하는 효과
-    window.history.pushState(null, "", "/choose");
+    navigate(`/start/${id}`)
     console.log(questionState);
-
-    // Choose 페이지로 이동할 때만 스크롤을 막습니다.
-    document.body.style.overflow = "auto";
   };
 
   // 면접 생성 API 함수
   const createInterview = async () => {
+    if(!startClicked) return;
     try {
       setIsLoading(true);
       // 전체 질문 개수 update
       const { project, cs, personality } = questionState.counts;
       const total = project + cs + personality;
       setTotalQuestionCountState(total);
-      console.log(total);
 
       const response = await api.post("interviews/create/", {
         user: githubLoginInfo.id,
@@ -665,19 +664,21 @@ function Choose() {
         type_names: selectedMultiButtons,
       });
       handleStartClick(response.data.id);
-      console.log(response.data);
+
       // 음성 면접인 경우에만 처리
       if (selectedInterviewType !== "video") {
         setShowVideoComponent(false);
       }
     } catch (e) {
-      console.log(e);
+      console.error(e);
     }
     setIsLoading(false);
   };
+  
 
   // 이력서 목록 조회 API
   useEffect(() => {
+    window.scrollTo(0,0);
     const getResumes = async () => {
       try {
         const response = await api.get("resumes/");
@@ -688,6 +689,7 @@ function Choose() {
     };
 
     getResumes();
+    
   }, []);
 
   // 드롭다운 메뉴 만드는 Array
@@ -868,7 +870,7 @@ function Choose() {
         </Container4>
         <Container4>
           <TextWrapper2>
-            <Text1>Github reposiotries</Text1>
+            <Text1>Github repositories</Text1>
             <Text3>복수 선택이 가능합니다.</Text3>
           </TextWrapper2>
           <RepoContainer>

--- a/2023winterbootcamp/src/Choosepage.tsx
+++ b/2023winterbootcamp/src/Choosepage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, Suspense } from "react";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import { useNavigate } from "react-router-dom";
 import api from "./baseURL/baseURL";
 import LoadingModal from "./components/LoadingModal";
@@ -336,12 +336,14 @@ const Start = styled.button<{ $startClicked: boolean }>`
   margin-bottom: 100px;
   margin-left: 70%;
   border: none;
-  cursor: pointer;
   user-select: none;
-  &:hover {
-    background-color: ${(props) =>
-      props.$startClicked ? "#1a1a1a" : "#1a1a1a"};
+  ${(props) => props.$startClicked && css`
+    cursor: pointer;
+    &:hover {
+    background-color: "#1a1a1a";
   }
+  `}
+  
 `;
 
 const DropdownContainer = styled.div`
@@ -548,20 +550,18 @@ function Choose() {
   // question_type의 count가 바뀔때마다 실행
   useEffect(() => {
     updateSelectedQuestionCounts();
-    console.log(questionState);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [projectCount, csCount, personalityCount]);
 
   // 모든 칸이 입력돼야 면접을 시작할 수 있음
   useEffect(() => {
     const isAllSelected =
-      selectedMultiButtons.length > 0 &&
+      Boolean(projectCount || csCount || personalityCount) &&
       selectedPosition !== null &&
       selectedInterviewType !== null &&
       selectedResume !== null &&
       selectedRepos.length > 0 &&
       title !== "";
-
     setStartClicked(isAllSelected);
   }, [
     selectedMultiButtons,
@@ -570,6 +570,9 @@ function Choose() {
     selectedResume,
     selectedRepos,
     title,
+    projectCount,
+    csCount,
+    personalityCount,
   ]);
 
   // 면접 제목 Change 이벤트 함수
@@ -638,22 +641,20 @@ function Choose() {
   const handleStartClick = (id: number) => {
     setStartClicked(true);
     // 다른 페이지로 이동하는 대신 현재 페이지의 URL을 변경하여 Choose 페이지로 이동하는 효과
-    window.history.pushState(null, "", "/choose");
-    console.log(questionState);
-
+    navigate(`/start/${id}`)
     // Choose 페이지로 이동할 때만 스크롤을 막습니다.
     document.body.style.overflow = "auto";
   };
 
   // 면접 생성 API 함수
   const createInterview = async () => {
+    if(!startClicked) return;
     try {
       setIsLoading(true);
       // 전체 질문 개수 update
       const { project, cs, personality } = questionState.counts;
       const total = project + cs + personality;
       setTotalQuestionCountState(total);
-      console.log(total);
 
       const response = await api.post("interviews/create/", {
         user: githubLoginInfo.id,
@@ -665,19 +666,20 @@ function Choose() {
         type_names: selectedMultiButtons,
       });
       handleStartClick(response.data.id);
-      console.log(response.data);
+
       // 음성 면접인 경우에만 처리
       if (selectedInterviewType !== "video") {
         setShowVideoComponent(false);
       }
     } catch (e) {
-      console.log(e);
+      console.error(e);
     }
     setIsLoading(false);
   };
 
   // 이력서 목록 조회 API
   useEffect(() => {
+    window.scrollTo(0,0);
     const getResumes = async () => {
       try {
         const response = await api.get("resumes/");
@@ -688,6 +690,7 @@ function Choose() {
     };
 
     getResumes();
+    
   }, []);
 
   // 드롭다운 메뉴 만드는 Array

--- a/2023winterbootcamp/src/Choosepage.tsx
+++ b/2023winterbootcamp/src/Choosepage.tsx
@@ -9,7 +9,7 @@ import {
   repoListState,
   totalQuestionCountState,
 } from "./Recoil";
-import { useRecoilState, useRecoilValue } from "recoil";
+import { useRecoilState, useRecoilValue, useResetRecoilState } from "recoil";
 import { interviewTypeState } from "./Recoil";
 import { useLocation } from "react-router-dom";
 
@@ -508,6 +508,7 @@ function Choose() {
   const [, setTotalQuestionCountState] = useRecoilState(
     totalQuestionCountState
   );
+  const resetCurrentQuestion = useResetRecoilState(currentQuestionState);
 
   // question_type 관련 함수
   const handleProjectCountChange = (
@@ -526,15 +527,14 @@ function Choose() {
 
   // question_type의 count에 따라 currentType 업데이트하는 함수
   const updateSelectedQuestionCounts = () => {
+    
     setQuestionState((prevState) => {
       let newCurrentType = prevState.currentType;
-
       if (projectCount === 0 && csCount > 0) {
         newCurrentType = "cs";
       } else if (projectCount === 0 && csCount === 0 && personalityCount > 0) {
         newCurrentType = "personality";
       }
-
       return {
         ...prevState,
         currentType: newCurrentType,
@@ -595,7 +595,6 @@ function Choose() {
     } else {
       updatedSelectedButtons = [...selectedMultiButtons, buttonName];
     }
-
     setSelectedMultiButtons(updatedSelectedButtons);
   };
 
@@ -720,6 +719,11 @@ function Choose() {
       }
     };
   }, [startClicked]);
+
+  //면접선택 페이지 들어올 때마다 이전에 저장된 전역상태정보 초기화
+  useEffect(()=>{
+    resetCurrentQuestion();
+  },[])
 
   return (
     <>

--- a/2023winterbootcamp/src/Interviewpage.tsx
+++ b/2023winterbootcamp/src/Interviewpage.tsx
@@ -350,10 +350,10 @@ function Interviewpage() {
       console.log(response.data);
 
       // 새로운 question ID를 questionId 상태에 업데이트
-      if (response.data && response.data.question) {
-        setQuestionId(response.data.question.id);
-        setQuestionType(response.data.question.question_type);
-        setQuestionContent(response.data.question.content);
+      if (response.data && response.data.questions) {
+        setQuestionId(response.data.questions[0].id);
+        setQuestionType(response.data.questions[0].question_type);
+        setQuestionContent(response.data.questions[0].content);
         updateQuestionState(); // question_type count 차감 및 다음 question_type 변경
       }
       setIsLoading(false);

--- a/2023winterbootcamp/src/Interviewpage.tsx
+++ b/2023winterbootcamp/src/Interviewpage.tsx
@@ -130,8 +130,8 @@ const commonStyle = `
 
 interface LeoBorderProps {
   color: string;
-  gradientColor: string;
-  animationDuration: number;
+  $gradientColor: string;
+  $animationDuration: number;
 }
 
 const SpinnerBox = styled.div`
@@ -149,21 +149,21 @@ const LeoBorder = styled.div<LeoBorderProps>`
   background: ${(props) => props.color};
   background: linear-gradient(
     0deg,
-    rgba(${(props) => props.gradientColor}, 0.1) 33%,
-    rgba(${(props) => props.gradientColor}, 1) 100%
+    rgba(${(props) => props.$gradientColor}, 0.1) 33%,
+    rgba(${(props) => props.$gradientColor}, 1) 100%
   );
-  animation: ${spin3D} ${(props) => props.animationDuration}s linear 0s infinite;
+  animation: ${spin3D} ${(props) => props.$animationDuration}s linear 0s infinite;
 `;
 
 interface LeoCoreProps {
-  backgroundColor: string;
+  $backgroundColor: string;
 }
 
 const LeoCore = styled.div<LeoCoreProps>`
   ${commonStyle}
   width: 100%;
   height: 100%;
-  background-color: ${(props) => props.backgroundColor};
+  background-color: ${(props) => props.$backgroundColor};
 `;
 
 const InstructionText = styled.div`
@@ -518,17 +518,17 @@ function Interviewpage() {
             <SpinnerBox>
               <LeoBorder
                 color="rgb(102, 102, 102)"
-                gradientColor="102, 102, 102"
-                animationDuration={1.8}
+                $gradientColor="102, 102, 102"
+                $animationDuration={1.8}
               >
-                <LeoCore backgroundColor="#191919aa" />
+                <LeoCore $backgroundColor="#191919aa" />
               </LeoBorder>
               <LeoBorder
                 color="rgb(255, 215, 244)"
-                gradientColor="255, 215, 244"
-                animationDuration={2.2}
+                $gradientColor="255, 215, 244"
+                $animationDuration={2.2}
               >
-                <LeoCore backgroundColor="#bebebeaa" />
+                <LeoCore $backgroundColor="#bebebeaa" />
               </LeoBorder>
             </SpinnerBox>
           </VideoContainer>


### PR DESCRIPTION
* 메인페이지 하단에서 '면접보러가기' 눌렀을 때, 면접선택 페이지 상단으로 이동

* 면접 선택 페이지에서 면접개수 총합 0개면 버튼 비활성화

* 면접 선택 페이지에 진입할 때, 저장되어 있던 currentQuestionState 초기화
초기화 하지 않을 시 이전 상태에 저장되어 있던 currentType 때문에 현재의 currentType이 적용 안되는 오류 발생

* styled-components props 앞에 '$' 추가
콘솔창 오류 제거하기 위해
