### PR TITLE
[feat] 면접페이지 답변 제출 후 다음 버튼 보이지 않게 수정 & 질문 타입에 맞는 타이틀 별도 설정

### DIFF
--- a/2023winterbootcamp/src/Interviewpage.tsx
+++ b/2023winterbootcamp/src/Interviewpage.tsx
@@ -152,7 +152,8 @@ const LeoBorder = styled.div<LeoBorderProps>`
     rgba(${(props) => props.$gradientColor}, 0.1) 33%,
     rgba(${(props) => props.$gradientColor}, 1) 100%
   );
-  animation: ${spin3D} ${(props) => props.$animationDuration}s linear 0s infinite;
+  animation: ${spin3D} ${(props) => props.$animationDuration}s linear 0s
+    infinite;
 `;
 
 interface LeoCoreProps {
@@ -435,6 +436,7 @@ function Interviewpage() {
   // 마지막 question 답변 등록 API
   const sendLastAnswer = async (blob: Blob) => {
     if (!id || !blob) return;
+    setIsLoading(true);
     const file = new FormData();
     file.append("question", questionId.toString());
     file.append("record_url", blob);
@@ -459,6 +461,7 @@ function Interviewpage() {
     } catch (e) {
       console.log(e);
     }
+    setIsLoading(false);
   };
 
   //인터뷰 종료 메소드
@@ -483,7 +486,7 @@ function Interviewpage() {
     getQ2AudioData();
     btnRef.current?.style.setProperty("visibility", "hidden");
     instRef.current?.style.setProperty("visibility", "hidden");
-  }, [question]);
+  }, [questionContent]);
 
   //스탑워치 시작 기능
   useEffect(() => {

--- a/2023winterbootcamp/src/Interviewpage.tsx
+++ b/2023winterbootcamp/src/Interviewpage.tsx
@@ -195,6 +195,7 @@ function Interviewpage() {
   const [questionId, setQuestionId] = useState<number>(0);
   const [questionContent, setQuestionContent] = useState<string>("");
   const [questionType, setQuestionType] = useState<string>("");
+  const [questionTypeTitle, setQuestionTypeTitle] = useState<string>("common")
   const [questionState, setQuestionState] =
     useRecoilState(currentQuestionState);
   const questionTotalCount = useRecoilValue(totalQuestionCountState);
@@ -513,6 +514,14 @@ function Interviewpage() {
     return false;
   };
 
+  //질문 타입 바뀔 때마다 그에 맞는 질문 타이틀 설정
+  useEffect(()=>{
+    if(questionType === 'common') setQuestionTypeTitle('자기소개');
+    else if(questionType === 'project') setQuestionTypeTitle('프로젝트 질문');
+    else if(questionType === 'cs') setQuestionTypeTitle('CS 질문');
+    else if(questionType === 'personality') setQuestionTypeTitle('인성 면접 질문');
+  }, [questionType]);
+
   return (
     <>
       <Up onContextMenu={handleSelectStart}>
@@ -541,7 +550,7 @@ function Interviewpage() {
       </Up>
       <Down onContextMenu={handleSelectStart}>
         <Q>
-          <QuestionText>{questionType}</QuestionText>
+          <QuestionText>{questionTypeTitle}</QuestionText>
           <ContentText>{questionContent}</ContentText>
         </Q>
         <RecordBox>


### PR DESCRIPTION
수정사항

1. 면접페이지 답변 제출한 후 다음 질문 TTS 음성 파일 실행될 때, '다음 버튼' 이 보이던 오류 수정
2. 질문 타입(common, project, cs, personality)에 맞는 별도의 질문 타이틀(자기소개, 프로젝트 질문, CS 질문, 인성 면접 질문) 설정