### PR TITLE
feat: 면접페이지에서 다음 질문 넘어갈 때 화면 상단으로 스크롤 이동하는 기능 구현 & 인터뷰 페이지 면접 질문 안 보이던 오류 수정

### DIFF
--- a/2023winterbootcamp/src/Interviewpage.tsx
+++ b/2023winterbootcamp/src/Interviewpage.tsx
@@ -391,10 +391,11 @@ function Interviewpage() {
       //   updateQuestionState(); // question_type count 차감 및 다음 question_type 변경
       // }
       if (response?.data && response.data.question) {
-        setQuestionId(response.data.question.id);
-        setQuestionType(response.data.question.question_type);
-        setQuestionContent(response.data.question.content);
+        setQuestionId(response.data.question[0].id);
+        setQuestionType(response.data.question[0].question_type);
+        setQuestionContent(response.data.question[0].content);
         updateQuestionState(); // question_type count 차감 및 다음 question_type 변경
+        console.log(response.data)
       }
       setIsLoading(false);
     } catch (e) {

--- a/2023winterbootcamp/src/Interviewpage.tsx
+++ b/2023winterbootcamp/src/Interviewpage.tsx
@@ -415,6 +415,7 @@ function Interviewpage() {
     if (questionContent !== "") {
       getQ2AudioData();
     }
+    window.scrollTo(0,0);
   }, [questionContent]);
 
   // 현재 question_type의 count 차감 및 다음 question_type으로 변경

--- a/2023winterbootcamp/src/components/LoadingModal.tsx
+++ b/2023winterbootcamp/src/components/LoadingModal.tsx
@@ -6,6 +6,7 @@ const BlackModalBackground = styled.div`
   width: 100%;
   height: 100%;
   position: fixed;
+  z-index: 3;
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%);


### PR DESCRIPTION
수정 및 변동사항

1. 면접페이지에서 다음 질문 넘어갈 때 화면 상단 보여주는 기능
2. 인터뷰 페이지에서 다음 질문 넘어갈 때 TTS 전송 안 되던 오류 수정(답변 받아올 때 question.content -> question[0].content로 수정)
3. 메인페이지에서 이력서 등록시 로딩창 잘 안 보이던 오류 수정