### PR TITLE
feat: 면접 결과페이지 이력서 삭제됐으면 삭제된 이력서라고 표시 재수정

### DIFF
--- a/2023winterbootcamp/src/Resultpage.tsx
+++ b/2023winterbootcamp/src/Resultpage.tsx
@@ -483,6 +483,20 @@ const Resultpage = () => {
     getResultInfo();
   }, []);
 
+  const [resumeTitle, setResumeTitle] = useState('');
+  useEffect(()=>{
+    if(!resumeTitle){
+      setResumeTitle("삭제된 이력서");
+      return;
+    }
+    resumeList.forEach((item,idx) => {
+      if(item.id === interviewResult.resume){
+        setResumeTitle(item.title);
+        return;
+      }
+    })
+  },[interviewResult])
+
   return (
     <>
       {interviewResult && (
@@ -549,10 +563,7 @@ const Resultpage = () => {
                       })()}
                     </Text3>
                     <Text3>
-                      {resumeList.map((item, idx) => {
-                        if (item.id === interviewResult.resume)
-                          return item.title;
-                      })}
+                      {resumeTitle}
                     </Text3>
                     <Text3>{interviewResult.repo_names.join(", ")}</Text3>
                   </TextBox3>


### PR DESCRIPTION
수정 및 변경사항

1. 면접 결과 조회시 등록했던 이력서가 삭제되었을 경우 '삭제된 이력서'라고 표시하는 기능 추가